### PR TITLE
capturable -> name + secure HTTP endpoint

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,3 +3,4 @@ max_x: 5000
 max_y: 5000
 max_z: 100
 ping_interval: 20
+api_key: 0cbf88f3-a487-4b9c-8e56-33defd257a26

--- a/turg/config.py
+++ b/turg/config.py
@@ -30,6 +30,7 @@ class Config(object):
     max_y = None
     max_z = None
     ping_interval = None
+    api_key = None
 
     def __init__(self):
         Config.load()
@@ -52,3 +53,10 @@ class Config(object):
         Config.max_y = get_from_env_or_config(config, 'max_y', 1000)
         Config.max_z = get_from_env_or_config(config, 'max_z', 100)
         Config.ping_interval = get_from_env_or_config(config, 'ping_interval', 20)
+
+        api_key = get_from_env_or_config(config, 'api_key', None)
+
+        if not api_key or api_key == 'None':
+            raise ValueError("api_key parameter is missing in configuration")
+
+        Config.api_key = api_key

--- a/turg/models.py
+++ b/turg/models.py
@@ -70,10 +70,12 @@ async def store_voxel(voxel: Voxel, db):
         await db.leaderboard.update_one({'owner': occupied[0]['owner']},
                                         {'$inc': {'time': ownership_time}},
                                         upsert=True)
-        return
+        voxel.capturable = True
+        return voxel
 
     conflict = [n for n in neighbours if n['owner'] != voxel.owner]
     logger.info("VOXEL: %s, N: %s", voxel, neighbours)
+
     if occupied:
         occupied[0].pop('capturable', None)
         occupied[0].pop('updated', None)
@@ -87,6 +89,7 @@ async def store_voxel(voxel: Voxel, db):
                           "conflict": conflict})
 
     await db.data.insert_one(attr.asdict(voxel))
+    return voxel
 
 
 async def get_leaders(db):

--- a/turg/views/voxels.py
+++ b/turg/views/voxels.py
@@ -21,7 +21,7 @@ class Voxels(web.View):
     async def post(self):
         try:
             payload = await self.request.json()
-            payload.pop('capturable', None)
+            payload.pop('name', None)
             if not verify_payload(payload):
                 raise ValueError("Incorrect payload")
             voxel = Voxel(**payload)

--- a/turg/views/voxels.py
+++ b/turg/views/voxels.py
@@ -3,6 +3,7 @@ from aiohttp import web
 from turg.config import Config
 from turg.logger import getLogger
 from turg.models import Voxel, get_voxels, store_voxel, verify_payload
+from turg.views.websocket import broadcast
 
 logger = getLogger()
 config = Config()
@@ -34,10 +35,11 @@ class Voxels(web.View):
         db = self.request.app['db']
 
         try:
-            await store_voxel(voxel, db)
+            voxel = await store_voxel(voxel, db)
         except ValueError:
             return web.json_response({'error': {'message': 'Invalid voxel location'}}, status=409)
         else:
+            await broadcast(voxel, self.request.app, {'id': None, 'type': 'update'})
             return web.json_response({'status': 'ok'}, status=200)
 
 

--- a/turg/views/voxels.py
+++ b/turg/views/voxels.py
@@ -3,6 +3,8 @@ from aiohttp import web
 from turg.config import Config
 from turg.logger import getLogger
 from turg.models import Voxel, get_voxels, store_voxel, verify_payload
+
+from turg.views import check_authorization
 from turg.views.websocket import broadcast
 
 logger = getLogger()
@@ -19,6 +21,7 @@ class Voxels(web.View):
 
         return web.json_response(data, status=200)
 
+    @check_authorization
     async def post(self):
         try:
             payload = await self.request.json()

--- a/turg/views/websocket.py
+++ b/turg/views/websocket.py
@@ -84,10 +84,8 @@ async def place(args, ws, app, meta):
             'meta': meta,
         })
 
-    voxel = Voxel(**args)
-
     try:
-        await store_voxel(voxel, app['db'])
+        voxel = await store_voxel(Voxel(**args), app['db'])
     except ValueError as e:
         res = {'error': {'message': str(e)},
                 'meta': meta,

--- a/turg/views/websocket.py
+++ b/turg/views/websocket.py
@@ -77,7 +77,7 @@ async def retrieve(args, ws, app, meta):
 
 
 async def place(args, ws, app, meta):
-    args.pop('capturable', None)
+    args.pop('name', None)
     if not verify_payload(args):
         return await ws.send_json({
             'error': {'message': 'Invalid payload'},
@@ -101,8 +101,8 @@ async def broadcast(data, app, meta):
     if not isinstance(data, dict):
         data = attr.asdict(data)
         data.pop('updated', None)
-        if not data.get('capturable'):
-            data.pop('capturable', None)
+        if not data.get('name'):
+            data.pop('name', None)
 
     for ws in app['websockets']:
         try:


### PR DESCRIPTION
This does the following:

1. Renames `capturable` field (boolean) to `name` (string) for flags.
2. Fixes bug with missing flag-specific in broadcasts after flag capture.
3. Secures POSTs for HTTP with an API key, stored in config or in the environment. **WARNING** backend will not start if `api_key` is missing in config (I hardcoded some GUID to `config.yml`) or env. It also makes REST endpoint broadcast new voxels to websocket clients.

Example of range request response:

```json
{
    "data": [
        {
            "x": 0,
            "y": 0,
            "z": 0,
            "owner": 1,
            "name": "Tower #1"
        },
        {
            "x": 5,
            "y": 0,
            "z": 0,
            "owner": 0
        }
    ],
    "meta": {
        "id": null,
        "type": "range"
    }
}
```