### PR TITLE
Add-hoc CORS support and declaration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,5 @@
 mongodb_uri: mongodb://mongo_db:27017/turg_db
+cors_host: 0.0.0.0:8008
 max_x: 5000
 max_y: 5000
 max_z: 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==2.2.5
+aiohttp_cors==0.5.3
 attrs==17.2.0
 uvloop==0.8.1
 motor==1.1

--- a/turg/config.py
+++ b/turg/config.py
@@ -70,3 +70,5 @@ class Config(object):
             raise ValueError("service_account parameter is missing in configuration")
 
         Config.service_account = service_account
+
+        Config.cors = get_from_env_or_config(config, 'cors_host', '*')

--- a/turg/firebase.py
+++ b/turg/firebase.py
@@ -1,19 +1,18 @@
-import os
-import json
 import asyncio
+import json
 
-from google.oauth2 import service_account
 from google.auth.transport.requests import AuthorizedSession
+from google.oauth2 import service_account
 
-from turg.logger import getLogger
 from turg.config import Config
+from turg.logger import getLogger
 
 logger = getLogger()
 config = Config()
 
 scopes = [
-  'https://www.googleapis.com/auth/userinfo.email',
-  'https://www.googleapis.com/auth/firebase.database',
+    'https://www.googleapis.com/auth/userinfo.email',
+    'https://www.googleapis.com/auth/firebase.database',
 ]
 
 

--- a/turg/main.py
+++ b/turg/main.py
@@ -1,4 +1,6 @@
 import asyncio
+import aiohttp_cors
+
 from aiohttp import web
 from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo import ASCENDING
@@ -19,12 +21,17 @@ config = Config()
 def create_app():
     app = web.Application()
 
+    # Configure default CORS settings.
+    cors = aiohttp_cors.setup(app, )
+
     for view in (voxels, websocket, leaderboard):
         routes = view.factory(app)
         routes = routes if isinstance(routes, list) else [routes]
         for route in routes:
-            app.router.add_route(**route)
-
+            resoure_cors = None
+            if hasattr(view, 'cors'):
+                resoure_cors = {config.cors: aiohttp_cors.ResourceOptions(**view.cors())}
+            cors.add(app.router.add_route(**route), resoure_cors)
     return app
 
 

--- a/turg/views/leaderboard.py
+++ b/turg/views/leaderboard.py
@@ -17,8 +17,16 @@ class Leaders(web.View):
 
 def factory(app):
     return {
-            'method': 'GET',
-            'path': '/v1/leaderboard/',
-            'handler': Leaders,
-            'expect_handler': web.Request.json,
-        }
+        'method': 'GET',
+        'path': '/v1/leaderboard/',
+        'handler': Leaders,
+        'expect_handler': web.Request.json,
+    }
+
+
+def cors():
+    return {
+        'allow_credentials': True,
+        'expose_headers': '*',
+        'allow_headers': '*'
+    }


### PR DESCRIPTION
For CORS support 
- define global `Access-Control-Allow-Origin` in config.yml with `cors_host` parameter
- define `cors()` func in your view module:
```python
def cors():
    return {
        'allow_credentials': True,
        'expose_headers': '*',
        'allow_headers': '*'
    }
```

Example:
```bash
⇒  http --verbose http://0.0.0.0:8008/v1/leaderboard/ Origin:0.0.0.0:8008 Access-Control-Request-Method:GET Access-Control-Request-Headers:X-Requested-With
GET /v1/leaderboard/ HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Access-Control-Request-Headers: X-Requested-With
Access-Control-Request-Method: GET
Connection: keep-alive
Host: 0.0.0.0:8008
Origin: 0.0.0.0:8008
User-Agent: HTTPie/0.9.9



HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: 0.0.0.0:8008
Access-Control-Expose-Headers:
Content-Length: 180
Content-Type: application/json; charset=utf-8
Date: Sun, 29 Oct 2017 14:47:32 GMT
Server: Python/3.6 aiohttp/2.2.5

[
    {
        "owner": "#ff00ff",
        "time": 147871.01936600002
    },
    {
        "owner": "#04a04d",
        "time": 78754.273838
    },
    {
        "owner": "#6dd9f9",
        "time": 60995.408399
    },
    {
        "owner": "#e285d6",
        "time": 283.921138
    }
]
```

